### PR TITLE
INT-4799 - Handle potentially `undefined` properties on Panoptica clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,15 @@ and this project adheres to
 
 ## [Unreleased]
 
+## 1.1.2 - 2022-07-27
+
+### Fixed
+
+- Handle potentially `undefined` properties on Panoptica clusters
+
 ## 1.1.1 - 2022-07-26
+
+### Fixed
 
 - Remove `email` from required integration configuration values
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-panoptica",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "A JupiterOne Integration for ingesting data of the Panoptica",
   "license": "MPL-2.0",
   "main": "src/index.js",

--- a/src/steps/cluster/converter.ts
+++ b/src/steps/cluster/converter.ts
@@ -27,8 +27,8 @@ export function createClusterEntity(cluster: PanopticaCluster): Entity {
         isPersistent: cluster.isPersistent,
         isMultiCluster: cluster.isMultiCluster,
         enableConnectionsControl: cluster.enableConnectionsControl,
-        proxyConfigurationEnableProxy: cluster.proxyConfiguration.enableProxy,
-        proxyConfigurationHttpsProxy: cluster.proxyConfiguration.httpsProxy,
+        proxyConfigurationEnableProxy: cluster.proxyConfiguration?.enableProxy,
+        proxyConfigurationHttpsProxy: cluster.proxyConfiguration?.httpsProxy,
         agentFailClose: cluster.agentFailClose,
         serviceDiscoveryIsolationEnabled:
           cluster.serviceDiscoveryIsolationEnabled,
@@ -41,19 +41,19 @@ export function createClusterEntity(cluster: PanopticaCluster): Entity {
         autoLabelEnabled: cluster.autoLabelEnabled,
         tlsInspectionEnabled: cluster.tlsInspectionEnabled,
         tracingSupportSettingsInstallTracingSupport:
-          cluster.tracingSupportSettings.installTracingSupport,
+          cluster.tracingSupportSettings?.installTracingSupport,
         tracingSupportSettingsTraceAnalyzerEnabled:
-          cluster.tracingSupportSettings.traceAnalyzerEnabled,
+          cluster.tracingSupportSettings?.traceAnalyzerEnabled,
         tracingSupportSettingsSpecReconstructorEnabled:
-          cluster.tracingSupportSettings.specReconstructorEnabled,
+          cluster.tracingSupportSettings?.specReconstructorEnabled,
         istioInstallationParametersIsIstioAlreadyInstalled:
-          cluster.istioInstallationParameters.isIstioAlreadyInstalled,
+          cluster.istioInstallationParameters?.isIstioAlreadyInstalled,
         istioInstallationParametersIstioVersion:
-          cluster.istioInstallationParameters.istioVersion,
+          cluster.istioInstallationParameters?.istioVersion,
         internalRegistryParametersInternalRegistryEnabled:
-          cluster.internalRegistryParameters.internalRegistryEnabled,
-        externalCaId: cluster.externalCa.id || undefined,
-        externalCaName: cluster.externalCa.name || undefined,
+          cluster.internalRegistryParameters?.internalRegistryEnabled,
+        externalCaId: cluster.externalCa?.id || undefined,
+        externalCaName: cluster.externalCa?.name || undefined,
         apiIntelligenceDAST: cluster.apiIntelligenceDAST,
         autoUpdateEnabled: cluster.autoUpdateEnabled,
         orchestrationType: cluster.orchestrationType,


### PR DESCRIPTION
# Description

Fixes the following error:

```
Cannot read property 'installTracingSupport' of null
```

Handled additional potential cases as well.

## Summary

<!-- Summary here! -->

## Type of change

Please leave any irrelevant options unchecked.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## Checklist

### General Development Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

### Integration Development Checklist:

Please leave any irrelevant options unchecked.

- [ ] I have checked for additional permissions required to call any new API
      endpoints, and have documented any additional permissions in
      `jupiterone.md`, where necessary.
- [ ] My changes properly paginate the target service provider's API
- [ ] My changes properly handle rate limiting of the target service provider's
      API
- [ ] My new integration step is instrumented to execute in the correct order
      using `dependsOn`
- [ ] I have referred to the
      [JupiterOne data model](https://github.com/JupiterOne/data-model/tree/main/src/schemas)
      to ensure that any new entities/relationships, and relevant properties,
      match the recommended model for this class of data
- [ ] I have updated the `CHANGELOG.md` file to describe my changes
- [ ] When changes include modifications to existing graph data ingestion, I've
      reviewed all existing managed questions referencing the entities,
      relationships, and their property names, to ensure those questions still
      function with my changes.
